### PR TITLE
Version/add 3.3 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,9 @@ Index:
 ```
 The link be maded with the slugifyFn, you can [check the default](https://github.com/9gustin/react-notion-render/blob/main/src/utils/slugify.ts), or [pass a custom](#custom-title-url).
 
-#### Image 
+### Image 
+⚠️ **Now we support native notion images**, if you add a image in your notion page this package would render it ;). This option would not be deprecated, just a suggestion. <br />
+
 This it simple, allows you to use images(includes GIF's). The sintax are the same like [Markdown images](https://www.digitalocean.com/community/tutorials/markdown-markdown-images). For it you have to include next text into your notion page as simple text <br />
 
 **Example:** <br />

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ This is independient to the prop **useStyles**, you can combinate them or use se
 | rnr-bulleted_list_item | Bulleted List | ul |
 | rnr-numbered_list_item | Numered List | ol |
 | rnr-toggle | Toggle List | ul |
+| rnr-video | Video | external: **iframe**, notion uploaded video: **video** |
 
 **Text Styles**  <br />
 | ClassName          | Notion Reference    |
@@ -187,36 +188,22 @@ Also you can add a link to image, like an image anchor. This link would be opene
 So when the user click my image in the blog it will be redirected to my github profile. <br />
 
 ### Video
+⚠️ **Now we support native notion videos**, if you add a video in your notion page this package would render it ;). This option would not be deprecated, just a suggestion <br />
 You can embed Videos. You have 3 ways to embed a video.
 
 - Local
 - Youtube
-- Google Drive
+- Google Drive (with a public share url)
 
-| Player | Description | Syntax | Example |
-| ---- | -------------- | ------ | --------- |
-| Local | Search in public folder | ` -[title](url) ` | ` -[Local](/loremVideo.mp4) ` |
-| Youtube | Youtube reproductor with share url | ` -[title](url)#youtube ` | ` -[Youtube](https://youtu.be/aA7si7AmPkY)#youtube ` |
-| Google Drive | Google drive reproductor with share url | ` -[title](url)#googleDrive ` | ` -[GoogleDrive](https://drive.google.com/file/d/1BmIxtck_9FuMfZOKfJDQK_WvIl8cDV11/view?usp=sharing)#googleDrive ` |
+**Structure:** <br />
+```
+-[title, or alternative text](url)
+```
 
-**How can i get Youtube video share url?:** <br />
-![youtubeStep1](https://user-images.githubusercontent.com/66853369/129779275-119a1dbb-0f38-485b-875c-1b7139e52e60.png)
-![youtubeStep2](https://user-images.githubusercontent.com/66853369/129779323-7141628d-761b-4e86-9609-5e4c8d308dc0.png)
-
-**How can i get Google Drive video share url?:** <br />
-Open the video
-<br />
-![image](https://user-images.githubusercontent.com/66853369/129779942-240ace25-32f7-4a17-bd8f-a84b7a280fab.png)
-<br />
-Click the 3 points icon then click Share
-<br />
-![image](https://user-images.githubusercontent.com/66853369/129780037-02f88faa-29e0-4b45-98e2-9982a1c45552.png)
-<br />
-Copy the ilnk
-<br />
-![image](https://user-images.githubusercontent.com/66853369/129780383-06e92d89-4e6c-46ce-be83-f6fea97c916a.png)
-
-
+**Example:** <br />
+```
+-[my youtube video](https://youtu.be/aA7si7AmPkY)
+```
 
 
 ### Display the table of contents

--- a/dev-example/data/mockVideos.json
+++ b/dev-example/data/mockVideos.json
@@ -1,0 +1,484 @@
+{
+  "object": "list",
+  "results": [
+    {
+      "object": "block",
+      "id": "68139e5e-9d1d-44da-b07b-2cc5748a3c86",
+      "created_time": "2021-08-29T00:42:00.000Z",
+      "last_edited_time": "2021-08-29T00:42:00.000Z",
+      "has_children": false,
+      "type": "paragraph",
+      "paragraph": {
+        "text": [
+          {
+            "type": "text",
+            "text": {
+              "content": "El objetivo es probar todas las posibilidades con video.",
+              "link": null
+            },
+            "annotations": {
+              "bold": false,
+              "italic": false,
+              "strikethrough": false,
+              "underline": false,
+              "code": false,
+              "color": "default"
+            },
+            "plain_text": "El objetivo es probar todas las posibilidades con video.",
+            "href": null
+          }
+        ]
+      }
+    },
+    {
+      "object": "block",
+      "id": "92cf141d-b612-4e21-9c05-d51d4c2aea33",
+      "created_time": "2021-08-29T00:42:00.000Z",
+      "last_edited_time": "2021-08-29T00:42:00.000Z",
+      "has_children": false,
+      "type": "paragraph",
+      "paragraph": {
+        "text": [
+          {
+            "type": "text",
+            "text": {
+              "content": "Alternativas contempladas:",
+              "link": null
+            },
+            "annotations": {
+              "bold": false,
+              "italic": false,
+              "strikethrough": false,
+              "underline": false,
+              "code": false,
+              "color": "default"
+            },
+            "plain_text": "Alternativas contempladas:",
+            "href": null
+          }
+        ]
+      }
+    },
+    {
+      "object": "block",
+      "id": "06ff73af-0247-4a92-a4cd-815a258c4259",
+      "created_time": "2021-08-29T00:42:00.000Z",
+      "last_edited_time": "2021-08-29T00:43:00.000Z",
+      "has_children": false,
+      "type": "bulleted_list_item",
+      "bulleted_list_item": {
+        "text": [
+          {
+            "type": "text",
+            "text": {
+              "content": "Custom component/ url interna",
+              "link": null
+            },
+            "annotations": {
+              "bold": false,
+              "italic": false,
+              "strikethrough": false,
+              "underline": false,
+              "code": false,
+              "color": "default"
+            },
+            "plain_text": "Custom component/ url interna",
+            "href": null
+          }
+        ]
+      }
+    },
+    {
+      "object": "block",
+      "id": "b35d9fc2-8ce9-47fb-88a5-6c1daed3e685",
+      "created_time": "2021-08-29T00:43:00.000Z",
+      "last_edited_time": "2021-08-29T00:43:00.000Z",
+      "has_children": false,
+      "type": "bulleted_list_item",
+      "bulleted_list_item": {
+        "text": [
+          {
+            "type": "text",
+            "text": {
+              "content": "Custom component/ youtube",
+              "link": null
+            },
+            "annotations": {
+              "bold": false,
+              "italic": false,
+              "strikethrough": false,
+              "underline": false,
+              "code": false,
+              "color": "default"
+            },
+            "plain_text": "Custom component/ youtube",
+            "href": null
+          }
+        ]
+      }
+    },
+    {
+      "object": "block",
+      "id": "7ebaee8c-8fcd-42cc-8b36-b11f19412098",
+      "created_time": "2021-08-29T00:43:00.000Z",
+      "last_edited_time": "2021-08-29T00:43:00.000Z",
+      "has_children": false,
+      "type": "bulleted_list_item",
+      "bulleted_list_item": {
+        "text": [
+          {
+            "type": "text",
+            "text": {
+              "content": "Custom component/ google drive",
+              "link": null
+            },
+            "annotations": {
+              "bold": false,
+              "italic": false,
+              "strikethrough": false,
+              "underline": false,
+              "code": false,
+              "color": "default"
+            },
+            "plain_text": "Custom component/ google drive",
+            "href": null
+          }
+        ]
+      }
+    },
+    {
+      "object": "block",
+      "id": "2011fbca-5192-441b-8ad0-18d24465b4ee",
+      "created_time": "2021-08-29T00:43:00.000Z",
+      "last_edited_time": "2021-08-29T00:43:00.000Z",
+      "has_children": false,
+      "type": "bulleted_list_item",
+      "bulleted_list_item": {
+        "text": [
+          {
+            "type": "text",
+            "text": {
+              "content": "Nativo/ link interno",
+              "link": null
+            },
+            "annotations": {
+              "bold": false,
+              "italic": false,
+              "strikethrough": false,
+              "underline": false,
+              "code": false,
+              "color": "default"
+            },
+            "plain_text": "Nativo/ link interno",
+            "href": null
+          }
+        ]
+      }
+    },
+    {
+      "object": "block",
+      "id": "c6a20f66-5f0c-4c75-95fb-f111f41f9534",
+      "created_time": "2021-08-29T00:43:00.000Z",
+      "last_edited_time": "2021-08-29T00:43:00.000Z",
+      "has_children": false,
+      "type": "bulleted_list_item",
+      "bulleted_list_item": {
+        "text": [
+          {
+            "type": "text",
+            "text": {
+              "content": "Nativo/ link externo",
+              "link": null
+            },
+            "annotations": {
+              "bold": false,
+              "italic": false,
+              "strikethrough": false,
+              "underline": false,
+              "code": false,
+              "color": "default"
+            },
+            "plain_text": "Nativo/ link externo",
+            "href": null
+          }
+        ]
+      }
+    },
+    {
+      "object": "block",
+      "id": "0d026b82-572b-4365-bf11-cf1dedd1bd13",
+      "created_time": "2021-08-29T00:43:00.000Z",
+      "last_edited_time": "2021-08-29T00:43:00.000Z",
+      "has_children": false,
+      "type": "heading_1",
+      "heading_1": {
+        "text": [
+          {
+            "type": "text",
+            "text": {
+              "content": "Custom component/ url interna",
+              "link": null
+            },
+            "annotations": {
+              "bold": false,
+              "italic": false,
+              "strikethrough": false,
+              "underline": false,
+              "code": false,
+              "color": "default"
+            },
+            "plain_text": "Custom component/ url interna",
+            "href": null
+          }
+        ]
+      }
+    },
+    {
+      "object": "block",
+      "id": "b8f1fed6-343a-4012-a7c9-141bf623b7e4",
+      "created_time": "2021-08-29T00:44:00.000Z",
+      "last_edited_time": "2021-08-29T00:45:00.000Z",
+      "has_children": false,
+      "type": "paragraph",
+      "paragraph": {
+        "text": [
+          {
+            "type": "text",
+            "text": {
+              "content": "-[Local](/loremVideo.mp4)",
+              "link": null
+            },
+            "annotations": {
+              "bold": false,
+              "italic": false,
+              "strikethrough": false,
+              "underline": false,
+              "code": false,
+              "color": "default"
+            },
+            "plain_text": "-[Local](/loremVideo.mp4)",
+            "href": null
+          }
+        ]
+      }
+    },
+    {
+      "object": "block",
+      "id": "4d3da782-e312-4934-ba7c-906c4f6a1d8f",
+      "created_time": "2021-08-29T00:43:00.000Z",
+      "last_edited_time": "2021-08-29T00:44:00.000Z",
+      "has_children": false,
+      "type": "heading_1",
+      "heading_1": {
+        "text": [
+          {
+            "type": "text",
+            "text": {
+              "content": "Custom component/ youtube",
+              "link": null
+            },
+            "annotations": {
+              "bold": false,
+              "italic": false,
+              "strikethrough": false,
+              "underline": false,
+              "code": false,
+              "color": "default"
+            },
+            "plain_text": "Custom component/ youtube",
+            "href": null
+          }
+        ]
+      }
+    },
+    {
+      "object": "block",
+      "id": "86cb9fcd-7a03-4e50-a771-15189c41d9f9",
+      "created_time": "2021-08-29T00:45:00.000Z",
+      "last_edited_time": "2021-08-29T00:45:00.000Z",
+      "has_children": false,
+      "type": "paragraph",
+      "paragraph": {
+        "text": [
+          {
+            "type": "text",
+            "text": {
+              "content": "-[Youtube](https://youtu.be/aA7si7AmPkY)#youtube",
+              "link": null
+            },
+            "annotations": {
+              "bold": false,
+              "italic": false,
+              "strikethrough": false,
+              "underline": false,
+              "code": false,
+              "color": "default"
+            },
+            "plain_text": "-[Youtube](https://youtu.be/aA7si7AmPkY)#youtube",
+            "href": null
+          }
+        ]
+      }
+    },
+    {
+      "object": "block",
+      "id": "e0c33fe4-3b62-4660-9ad9-6e46877e54f9",
+      "created_time": "2021-08-29T00:43:00.000Z",
+      "last_edited_time": "2021-08-29T00:44:00.000Z",
+      "has_children": false,
+      "type": "heading_1",
+      "heading_1": {
+        "text": [
+          {
+            "type": "text",
+            "text": {
+              "content": "Custom component/ google drive",
+              "link": null
+            },
+            "annotations": {
+              "bold": false,
+              "italic": false,
+              "strikethrough": false,
+              "underline": false,
+              "code": false,
+              "color": "default"
+            },
+            "plain_text": "Custom component/ google drive",
+            "href": null
+          }
+        ]
+      }
+    },
+    {
+      "object": "block",
+      "id": "7affd4b1-0bb4-4628-b1b7-a27801e3e664",
+      "created_time": "2021-08-29T00:46:00.000Z",
+      "last_edited_time": "2021-08-29T00:47:00.000Z",
+      "has_children": false,
+      "type": "paragraph",
+      "paragraph": {
+        "text": [
+          {
+            "type": "text",
+            "text": {
+              "content": "-[GoogleDrive](https://drive.google.com/file/d/1ywJdRoTv25tzvsazX3HpglP_3fNDLO2i/view?usp=sharing)#googleDrive",
+              "link": null
+            },
+            "annotations": {
+              "bold": false,
+              "italic": false,
+              "strikethrough": false,
+              "underline": false,
+              "code": false,
+              "color": "default"
+            },
+            "plain_text": "-[GoogleDrive](https://drive.google.com/file/d/1ywJdRoTv25tzvsazX3HpglP_3fNDLO2i/view?usp=sharing)#googleDrive",
+            "href": null
+          }
+        ]
+      }
+    },
+    {
+      "object": "block",
+      "id": "0c06ac16-1b0e-4776-a2f0-811b43202387",
+      "created_time": "2021-08-29T00:43:00.000Z",
+      "last_edited_time": "2021-08-29T00:44:00.000Z",
+      "has_children": false,
+      "type": "heading_1",
+      "heading_1": {
+        "text": [
+          {
+            "type": "text",
+            "text": {
+              "content": "Nativo/ link interno",
+              "link": null
+            },
+            "annotations": {
+              "bold": false,
+              "italic": false,
+              "strikethrough": false,
+              "underline": false,
+              "code": false,
+              "color": "default"
+            },
+            "plain_text": "Nativo/ link interno",
+            "href": null
+          }
+        ]
+      }
+    },
+    {
+      "object": "block",
+      "id": "985a855a-1515-40e9-914f-91440705e247",
+      "created_time": "2021-08-29T00:47:00.000Z",
+      "last_edited_time": "2021-08-29T00:47:00.000Z",
+      "has_children": false,
+      "type": "video",
+      "video": {
+        "caption": [],
+        "type": "file",
+        "file": {
+          "url": "https://s3.us-west-2.amazonaws.com/secure.notion-static.com/b97901f7-7dcf-4d05-b623-523379c4692c/samplevideo.mp4?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAT73L2G45O3KS52Y5%2F20210829%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20210829T004817Z&X-Amz-Expires=3600&X-Amz-Signature=6e0c7cab0efec66e60ed58df75f92e0955e2865cb1156e8f314657ea2dde6f01&X-Amz-SignedHeaders=host",
+          "expiry_time": "2021-08-29T01:48:17.296Z"
+        }
+      }
+    },
+    {
+      "object": "block",
+      "id": "c5ad3c67-1b5e-490d-8ef7-d684eedf9531",
+      "created_time": "2021-08-29T00:43:00.000Z",
+      "last_edited_time": "2021-08-29T00:47:00.000Z",
+      "has_children": false,
+      "type": "heading_1",
+      "heading_1": {
+        "text": [
+          {
+            "type": "text",
+            "text": {
+              "content": "Nativo/ link externo (youtube)",
+              "link": null
+            },
+            "annotations": {
+              "bold": false,
+              "italic": false,
+              "strikethrough": false,
+              "underline": false,
+              "code": false,
+              "color": "default"
+            },
+            "plain_text": "Nativo/ link externo (youtube)",
+            "href": null
+          }
+        ]
+      }
+    },
+    {
+      "object": "block",
+      "id": "574f8113-bce4-448f-98a1-22e499e71af7",
+      "created_time": "2021-08-29T00:47:00.000Z",
+      "last_edited_time": "2021-08-29T00:47:00.000Z",
+      "has_children": false,
+      "type": "video",
+      "video": {
+        "caption": [],
+        "type": "external",
+        "external": {
+          "url": "https://youtu.be/aA7si7AmPkY"
+        }
+      }
+    },
+    {
+      "object": "block",
+      "id": "5d95c6fd-0f03-41ab-8188-81d9479770aa",
+      "created_time": "2021-08-29T00:47:00.000Z",
+      "last_edited_time": "2021-08-29T00:47:00.000Z",
+      "has_children": false,
+      "type": "paragraph",
+      "paragraph": {
+        "text": []
+      }
+    }
+  ],
+  "next_cursor": null,
+  "has_more": false
+}

--- a/dev-example/pages/[id].js
+++ b/dev-example/pages/[id].js
@@ -29,7 +29,7 @@ export default function Post({ page, blocks }) {
         <article>
           <Render blocks={[page.properties.Name]}/>
           <section>
-            <Render blocks={blocks} emptyBlocks useStyles slugifyFn={(t) => {
+            <Render blocks={blocks} emptyBlocks classNames useStyles slugifyFn={(t) => {
               return t.replace(/[^a-zA-Z0-9]/g, '_')
             }}/>
             <Link href='/blog'>

--- a/dev-example/pages/index.js
+++ b/dev-example/pages/index.js
@@ -2,7 +2,7 @@ import React from 'react'
 import Link from 'next/link'
 import { Render } from '@9gustin/react-notion-render'
 
-import notionResponse from '../data/blocks.json'
+import notionResponse from '../data/mockVideos.json'
 import title from '../data/title.json'
 
 export default function mockedPage() {
@@ -13,9 +13,8 @@ export default function mockedPage() {
         <Link href='/blog'>/blog</Link>
       </h3>
       <Render blocks={[title.properties.Name]}/>
-      {/* <h1>{renderTitle(title.properties.Name)}</h1> */}
       <article>
-        <Render blocks={notionResponse.results} />
+        <Render blocks={notionResponse.results} classNames/>
       </article>
     </div>
   )

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@9gustin/react-notion-render",
-  "version": "3.3.0-beta.1",
+  "version": "3.3.0-beta.2",
   "description": "A library to render notion content",
   "author": "9gustin",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@9gustin/react-notion-render",
-  "version": "3.3.0-beta.0",
+  "version": "3.3.0-beta.1",
   "description": "A library to render notion content",
   "author": "9gustin",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@9gustin/react-notion-render",
-  "version": "3.3.0-beta.3",
+  "version": "3.3.0",
   "description": "A library to render notion content",
   "author": "9gustin",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@9gustin/react-notion-render",
-  "version": "3.3.0-beta.2",
+  "version": "3.3.0-beta.3",
   "description": "A library to render notion content",
   "author": "9gustin",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@9gustin/react-notion-render",
-  "version": "3.2.0",
+  "version": "3.3.0-beta.0",
   "description": "A library to render notion content",
   "author": "9gustin",
   "keywords": [

--- a/src/components/common/Embed/index.tsx
+++ b/src/components/common/Embed/index.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import { DropedProps } from '../../../hoc/withContentValidation'
+
+export type Props = {
+  className?: string
+  media?: DropedProps['media']
+  frameBorder?: string
+  allow?: string
+  allowFullScreen?: boolean
+}
+
+function Embed({
+  media,
+  className,
+  frameBorder,
+  allow,
+  allowFullScreen
+}: Props) {
+  if (!media) return null
+
+  const { src, alt } = media
+
+  return (
+    <iframe
+      src={src}
+      title={alt}
+      className={`block ${className}`}
+      frameBorder={frameBorder ?? '0'}
+      allow={allow}
+      allowFullScreen={allowFullScreen}
+    />
+  )
+}
+
+export default Embed

--- a/src/components/common/Embed/wrappedEmbed.tsx
+++ b/src/components/common/Embed/wrappedEmbed.tsx
@@ -1,0 +1,4 @@
+import Embed from '.'
+import withContentValidation from '../../../hoc/withContentValidation'
+
+export default withContentValidation(Embed)

--- a/src/components/common/File/index.tsx
+++ b/src/components/common/File/index.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import withContentValidation, { DropedProps } from '../../../hoc/withContentValidation'
+import Link from '../Link'
+
+interface Props {
+  className?: string
+  media?: DropedProps['media']
+}
+
+function File({ media, className }: Props) {
+  if (!media) return null
+
+  const { src, name, extension } = media
+
+  const cn = `block ${className ?? ''}`
+
+  return (
+    <Link url={src} className={cn}>
+      {name}.{extension}
+    </Link>
+  )
+}
+
+export default withContentValidation(File)

--- a/src/components/common/Image/index.tsx
+++ b/src/components/common/Image/index.tsx
@@ -1,15 +1,17 @@
 import React from 'react'
+import { DropedProps } from '../../../hoc/withContentValidation'
 
 export interface Props {
-  src: string
-  alt: string
-  href?: string
+  className?: string
+  media?: DropedProps['media']
 }
 
-function Image({ src, alt, href }: Props) {
+function Image({ className, media }: Props) {
+  if (!media) return null
+  const { src, alt, href } = media
   return (
-    <a href={href || src} target='_blank' rel='noreferrer'>
-      <img src={src} alt={alt} />
+    <a className={className} href={href} target='_blank' rel='noreferrer'>
+      <img src={src || href} alt={alt} />
     </a>
   )
 }

--- a/src/components/common/Image/wrappedImage.tsx
+++ b/src/components/common/Image/wrappedImage.tsx
@@ -1,0 +1,4 @@
+import Image from '.'
+import withContentValidation from '../../../hoc/withContentValidation'
+
+export default withContentValidation(Image)

--- a/src/components/common/Link/index.tsx
+++ b/src/components/common/Link/index.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 export interface Props {
   url: string
-  children: string
+  children: React.ReactNode
   className?: string
 }
 

--- a/src/components/common/Video/constants.tsx
+++ b/src/components/common/Video/constants.tsx
@@ -1,23 +1,50 @@
 import React from 'react'
 
-const PLAYERS = {
-  youtube: (url: string, title: string) => {
-    const videoCode = url.split('/')[3]
-    return (
-        <iframe
-        src={`https://www.youtube.com/embed/${videoCode}`}
-        title={title}
-        frameBorder="0"
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowFullScreen />
-    )
+const MATCHERS = [
+  {
+    name: 'youtube',
+    REGEXP:
+      /(?:youtu\.be\/|youtube\.com(?:\/embed\/|\/v\/|\/watch\?v=|\/user\/\S+|\/ytscreeningroom\?v=))([\w\-]{10,12})\b/,
+    getUrl: (src: string) => {
+      const GET_ID =
+        /(?:youtu\.be\/|youtube\.com(?:\/embed\/|\/v\/|\/watch\?v=|\/user\/\S+|\/ytscreeningroom\?v=|\/sandalsResorts#\w\/\w\/.*\/))([^\/&]{10,12})/
+      const id = src.match(GET_ID)?.[1]
+      return `https://www.youtube.com/embed/${id}`
+    }
   },
-  googleDrive: (url: string, title: string) => {
-    const videoUrl = url.split('/')
-    videoUrl.pop()
-    return (
-        <iframe title={title} src={`${videoUrl.join('/')}/preview`} allow="autoplay" />
-    )
+  {
+    name: 'googleDrive',
+    REGEXP: /drive.google.com/,
+    getUrl: (src: string) => {
+      const videoUrl = src.split('/')
+      videoUrl.pop()
+      return `${videoUrl.join('/')}/preview`
+    }
   }
+]
+
+export function getPlayer(src: string, alt: string, className?: string) {
+  const match = MATCHERS.find((option) => option.REGEXP.test(src))
+
+  if (!match) return null
+
+  return PLAYERS[match.name](match.getUrl ? match.getUrl(src) : src, alt, className)
+}
+
+const PLAYERS = {
+  youtube: (url: string, title: string, className?: string) => (
+    <iframe
+      src={url}
+      title={title}
+      frameBorder='0'
+      allow='accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture'
+      allowFullScreen
+      className={className}
+    />
+  ),
+  googleDrive: (url: string, title: string, className?: string) => (
+    <iframe title={title} src={url} allow='autoplay' className={className} />
+  )
 }
 
 export default PLAYERS

--- a/src/components/common/Video/constants.tsx
+++ b/src/components/common/Video/constants.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import Embed from '../Embed'
 
 const MATCHERS = [
   {
@@ -28,22 +29,28 @@ export function getPlayer(src: string, alt: string, className?: string) {
 
   if (!match) return null
 
-  return PLAYERS[match.name](match.getUrl ? match.getUrl(src) : src, alt, className)
+  return PLAYERS[match.name](
+    match.getUrl ? match.getUrl(src) : src,
+    alt,
+    className
+  )
 }
 
 const PLAYERS = {
   youtube: (url: string, title: string, className?: string) => (
-    <iframe
-      src={url}
-      title={title}
-      frameBorder='0'
+    <Embed
+      media={{ alt: title, src: url }}
+      className={className}
       allow='accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture'
       allowFullScreen
-      className={className}
     />
   ),
   googleDrive: (url: string, title: string, className?: string) => (
-    <iframe title={title} src={url} allow='autoplay' className={className} />
+    <Embed
+      media={{ alt: title, src: url }}
+      className={className}
+      allow='autoplay'
+    />
   )
 }
 

--- a/src/components/common/Video/index.tsx
+++ b/src/components/common/Video/index.tsx
@@ -1,22 +1,26 @@
 import React from 'react'
-import PLAYERS from './constants'
+import { DropedProps } from '../../../hoc/withContentValidation'
+import { getPlayer } from './constants'
 
-export interface Props {
-  title: string
-  src: string
-  player?: string
+export type Props = {
+  className?: string
+  media?: DropedProps['media']
 }
 
-function Video({ src, title, player }: Props) {
-  if (player) {
-    return PLAYERS[player]?.(src, title) || <h1>Error: {player} not found</h1>
-  }
+function Video({ media, className }: Props) {
+  if (!media) return null
+
+  const { src, alt } = media
+
+  const player = getPlayer(src, alt, className)
+
   return (
-      <video controls>
-          <source src={src}
-            type="video/mp4" />
-            {title}
+    player ?? (
+      <video className={className} controls>
+        <source src={src} type='video/mp4' />
+        {alt}
       </video>
+    )
   )
 }
 

--- a/src/components/common/Video/wrappedVideo.tsx
+++ b/src/components/common/Video/wrappedVideo.tsx
@@ -1,0 +1,4 @@
+import Video from '.'
+import withContentValidation from '../../../hoc/withContentValidation'
+
+export default withContentValidation(Video)

--- a/src/hoc/withContentValidation/constants.tsx
+++ b/src/hoc/withContentValidation/constants.tsx
@@ -10,7 +10,14 @@ export function getMediaProps (props: WithContentValidationProps) {
 
   if (!url) return undefined
 
+  const urlParts = url.match(/\/?([^/.]*)\.?([^/]*)$/)
+
+  const name = urlParts?.[1] ?? ''
+  const extension = urlParts?.[2].split('?')[0] ?? ''
+
   return {
+    name,
+    extension,
     alt: block.getPlainText(),
     src: url
   }

--- a/src/hoc/withContentValidation/constants.tsx
+++ b/src/hoc/withContentValidation/constants.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import { WithContentValidationProps } from '.'
+import Text from '../../types/Text'
+
+import RenderText from '../../components/core/Text'
+
+export function getMediaProps (props: WithContentValidationProps) {
+  const { block } = props
+  const url = block.getUrl()
+
+  if (!url) return undefined
+
+  return {
+    alt: block.getPlainText(),
+    src: url
+  }
+}
+
+export function getDefaultProps (props: WithContentValidationProps) {
+  const { block } = props
+  const plainText = block.getPlainText()
+
+  return {
+    checked: Boolean(block.content?.checked),
+    plainText: plainText,
+    children: block.content?.text.map((text: Text, index: number) => (
+      <RenderText key={index} {...text} />
+    ))
+  }
+}

--- a/src/hoc/withContentValidation/index.tsx
+++ b/src/hoc/withContentValidation/index.tsx
@@ -23,6 +23,7 @@ export interface DropedProps {
   media?: {
     alt: string
     src: string
+    href?: string
     name?: string
     extension?: string
     player?: string

--- a/src/hoc/withContentValidation/index.tsx
+++ b/src/hoc/withContentValidation/index.tsx
@@ -23,6 +23,8 @@ export interface DropedProps {
   media?: {
     alt: string
     src: string
+    name?: string
+    extension?: string
     player?: string
   }
 }

--- a/src/hoc/withCustomComponent/constants.ts
+++ b/src/hoc/withCustomComponent/constants.ts
@@ -35,9 +35,11 @@ export const customComponents: CustomComponent[] = [
     match: /!\[[^\]]*\]\((.*?)\s*("(?:.*[^"])")?\s*\)/,
     // eslint-disable-next-line camelcase
     transformProps: ({ plain_text }) => ({
-      alt: plain_text.split('![')[1].split(']')[0],
-      src: plain_text.split('(')[1].split(')')[0],
-      href: plain_text.indexOf('#') < 0 ? undefined : plain_text.substr(plain_text.indexOf('#')).replace('#', '')
+      media: {
+        alt: plain_text.split('![')[1].split(']')[0],
+        src: plain_text.split('(')[1].split(')')[0],
+        href: plain_text.indexOf('#') < 0 ? undefined : plain_text.substr(plain_text.indexOf('#')).replace('#', '')
+      }
     }),
     component: Image
   },

--- a/src/hoc/withCustomComponent/constants.ts
+++ b/src/hoc/withCustomComponent/constants.ts
@@ -23,9 +23,11 @@ export const customComponents: CustomComponent[] = [
     match: /-\[[^\]]*\]\((.*?)\s*("(?:.*[^"])")?\s*\)/,
     // eslint-disable-next-line camelcase
     transformProps: ({ plain_text }) => ({
-      title: plain_text.split('-[')[1].split(']')[0],
-      src: plain_text.split('(')[1].split(')')[0],
-      player: plain_text.indexOf('#') < 0 ? undefined : plain_text.substr(plain_text.indexOf('#')).replace('#', '')
+      media: {
+        alt: plain_text.split('-[')[1].split(']')[0],
+        src: plain_text.split('(')[1].split(')')[0],
+        player: plain_text.indexOf('#') < 0 ? undefined : plain_text.substr(plain_text.indexOf('#')).replace('#', '')
+      }
     }),
     component: Video
   },

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -24,6 +24,10 @@
   font-weight: var(--normal-weight);
 }
 
+:global(.rnr-container) > :global(.block){
+  display: block;
+}
+
 :global(.rnr-container) h1,
 :global(.rnr-container) h1 > * {
   font-size: var(--font-size-display-text);

--- a/src/types/Block.ts
+++ b/src/types/Block.ts
@@ -2,6 +2,7 @@ import DummyText from '../components/common/DummyText'
 import List from '../components/common/List'
 import Paragraph from '../components/common/Paragraph'
 import Title from '../components/common/Title'
+import Video from '../components/common/Video/wrappedVideo'
 import { blockEnum } from './BlockTypes'
 import { NotionBlock } from './NotionBlock'
 import Text from './Text'
@@ -13,6 +14,14 @@ export class ParsedBlock {
   content: null | {
     text: Text[]
     checked?: boolean
+    caption?: Text[]
+    type?: 'external' | 'file'
+    external?: {
+      url: string
+    }
+    file?: {
+      url: string
+    }
   }
 
   constructor(initialValues: NotionBlock, isChild?: boolean) {
@@ -31,13 +40,13 @@ export class ParsedBlock {
       this.content = null
       this.items = [new ParsedBlock(initialValues, true)]
     } else {
-      const { text, checked } = content
+      const { text, checked, caption, type, external, file } = content
 
       this.items =
         content.children?.map(
           (child: NotionBlock) => new ParsedBlock(child, true)
         ) ?? null
-      this.content = { text, checked }
+      this.content = { text: text ?? [], checked, caption, type, external, file }
     }
   }
 
@@ -57,6 +66,9 @@ export class ParsedBlock {
       case blockEnum.TOGGLE_LIST: {
         return List
       }
+      case blockEnum.VIDEO: {
+        return Video
+      }
       case blockEnum.TITLE: {
         return DummyText
       }
@@ -64,6 +76,12 @@ export class ParsedBlock {
         return null
       }
     }
+  }
+
+  getUrl() {
+    if (!this.content?.type || !this.isMedia()) return null
+
+    return this.content[this.content.type]?.url || null
   }
 
   getType() {
@@ -77,13 +95,20 @@ export class ParsedBlock {
       case blockEnum.HEADING2:
       case blockEnum.HEADING3:
         return 'TITLE'
+      case blockEnum.FILE:
+      case blockEnum.VIDEO:
+      case blockEnum.IMAGE:
+      case blockEnum.PDF:
+        return 'MEDIA'
       default:
         return 'ELEMENT'
     }
   }
 
   getPlainText() {
-    return this.content?.text.map((text: Text) => text.plain_text).join(' ') ?? ''
+    const textComponent = this.isMedia() ? this.content?.caption : this.content?.text
+
+    return textComponent?.map((text: Text) => text.plain_text).join(' ') ?? ''
   }
 
   isList() {
@@ -92,6 +117,10 @@ export class ParsedBlock {
 
   isTitle(): unknown {
     return this.getType() === 'TITLE'
+  }
+
+  isMedia(): unknown {
+    return this.getType() === 'MEDIA'
   }
 
   equalsType(type: blockEnum) {

--- a/src/types/Block.ts
+++ b/src/types/Block.ts
@@ -5,6 +5,7 @@ import List from '../components/common/List'
 import Paragraph from '../components/common/Paragraph'
 import Title from '../components/common/Title'
 import Video from '../components/common/Video/wrappedVideo'
+import Image from '../components/common/Image/wrappedImage'
 import { blockEnum } from './BlockTypes'
 import { NotionBlock } from './NotionBlock'
 import Text from './Text'
@@ -90,6 +91,9 @@ export class ParsedBlock {
       case blockEnum.TITLE: {
         return DummyText
       }
+      case blockEnum.IMAGE: {
+        return Image
+      }
       default: {
         return null
       }
@@ -106,7 +110,6 @@ export class ParsedBlock {
     } else if (this.isMedia() && this.content?.type) {
       url = this.content[this.content.type]?.url
     }
-
     return url || null
   }
 

--- a/src/types/Block.ts
+++ b/src/types/Block.ts
@@ -1,4 +1,5 @@
 import DummyText from '../components/common/DummyText'
+import File from '../components/common/File'
 import List from '../components/common/List'
 import Paragraph from '../components/common/Paragraph'
 import Title from '../components/common/Title'
@@ -68,6 +69,9 @@ export class ParsedBlock {
       }
       case blockEnum.VIDEO: {
         return Video
+      }
+      case blockEnum.FILE: {
+        return File
       }
       case blockEnum.TITLE: {
         return DummyText

--- a/src/types/BlockTypes.ts
+++ b/src/types/BlockTypes.ts
@@ -7,7 +7,13 @@ export enum blockEnum {
   DOTS_LIST = 'bulleted_list_item',
   ENUM_LIST = 'numbered_list_item',
   CHECK_LIST = 'to_do',
-  TITLE = 'title'
+  TITLE = 'title',
+  VIDEO = 'video',
+  IMAGE = 'image',
+  EMBED = 'embed',
+  FILE = 'file',
+  PDF = 'pdf',
+  BOOKMARK = 'bookmark',
 }
 
 export const UNSUPPORTED_TYPE = 'unsupported'


### PR DESCRIPTION
Integrate new blocks supported by notion API #53 

Now you can use native(in notion) blocks like:
- Images
- Videos
- Embeds (URL's or PDF's)
- Files

Before only text blocks were supported, such as p, h1, lists.

Includes PR's:
#54 #55 #56 #57 