### PR TITLE
V3.8: Update supported components: Add table, table of contents and synced blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,13 @@ This is independient to the prop **useStyles**, you can combinate them or use se
 | rnr-pdf | PDF | iframe |
 | rnr-callout | Callout | div |
 | rnr-quote | Quote | blockquote |
+| rnr-divider | Divider | hr |
+| rnr-code | Code | pre > code |
+| rnr-table_of_contents | Table of contents | ul |
+| rnr-table_of_contents | Table of contents | ul |
+| rnr-table | Table | table |
+| rnr-table_row | Table row | tr |
+
 
 **Text Styles**  <br />
 | ClassName          | Notion Reference    |

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
    - [Giving Styles](#giving-styles)
    - [...moreProps](#moreprops)
    - [Custom Components](#custom-components)
-   - [Display the table of contents](#display-the-table-of-contents)
+   - [Display a custom table of contents](#display-a-custom-table-of-contents)
  - [Supported blocks](#supported-blocks)
  - [Contributions](#contributions)
 
@@ -121,7 +121,6 @@ This is independient to the prop **useStyles**, you can combinate them or use se
 | rnr-quote | Quote | blockquote |
 | rnr-divider | Divider | hr |
 | rnr-code | Code | pre > code |
-| rnr-table_of_contents | Table of contents | ul |
 | rnr-table_of_contents | Table of contents | ul |
 | rnr-table | Table | table |
 | rnr-table_row | Table row | tr |
@@ -226,7 +225,7 @@ You can embed Videos. You have 3 ways to embed a video.
 ```
 
 
-### Display the table of contents
+### Display a custom table of contents
 
 Now we exporting the **indexGenerator** function, with that you can show a table of contents of your page content. This function receive a list of blocks and return only the title blocks. The structure of the result it's like:
 
@@ -279,11 +278,13 @@ Most common block types are supported. We happily accept pull requests to add su
 | Divider	| ✅ |
 | Link	| ✅ |	
 | Code | ✅ |
-| Web Bookmark |	❌ |	
 | Toggle List	| ✅ |	
 | Page Links	| ✅ |	
 | Checkbox	| ✅ (read-only) |
-| Table Of Contents	| ✅ [indexGenerator](#display-the-table-of-contents) |
+| Table Of Contents	| ✅ |
+| Table | ✅ |
+| Synced blocks | ✅ |
+| Web Bookmark |	❌ |	
 
 ## Contributions:
 If you find a bug, or want to suggest a feature you can create a [New Issue](https://github.com/9gustin/react-notion-render/issues/new) and will be analized. **Contributions of any kind welcome!**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@9gustin/react-notion-render",
-  "version": "3.8.0-beta.0",
+  "version": "3.8.0",
   "description": "A library to render notion content",
   "author": "9gustin",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@9gustin/react-notion-render",
-  "version": "3.7.0",
+  "version": "3.8.0-beta.0",
   "description": "A library to render notion content",
   "author": "9gustin",
   "keywords": [

--- a/src/components/common/Table/index.tsx
+++ b/src/components/common/Table/index.tsx
@@ -1,0 +1,46 @@
+import React from 'react'
+
+import withContentValidation, {
+  DropedProps
+} from '../../../hoc/withContentValidation'
+import IText from '../../../types/Text'
+import { blockTypeClassname } from '../../../utils/getClassname'
+
+import Text from '../../core/Text'
+
+type tableRowProps = {
+  cells: IText[][]
+  className?: string
+}
+function TableRow({ cells, className }: tableRowProps) {
+  return (
+    <tr className={className}>
+      {cells.map((cellTexts) => (
+        <td>
+          {cellTexts.map((text) => <Text {...text} />)}
+        </td>
+      ))}
+    </tr>
+  )
+}
+
+function Table({ className, config }: DropedProps) {
+  const { content, items } = config.block
+  const rows = items?.filter(({ content }) => content?.cells)
+
+  if (!rows) return null
+
+  const cn = `${className} ${
+    content?.hasColumnHeader ? 'has-column-header' : ''
+  } ${content?.hasRowHeader ? 'has-row-header' : ''}`.trim()
+
+  return (
+    <table className={cn}>
+      {rows.map(({ notionType, content }) => (
+        <TableRow className={blockTypeClassname(notionType)} cells={content!.cells!} />
+      ))}
+    </table>
+  )
+}
+
+export default withContentValidation(Table)

--- a/src/components/common/TableOfContents/index.tsx
+++ b/src/components/common/TableOfContents/index.tsx
@@ -1,0 +1,8 @@
+import React from 'react'
+import withContentValidation from '../../../hoc/withContentValidation'
+
+function TableOfContents() {
+  return <div>Table of contents</div>
+}
+
+export default withContentValidation(TableOfContents)

--- a/src/components/common/TableOfContents/index.tsx
+++ b/src/components/common/TableOfContents/index.tsx
@@ -1,8 +1,32 @@
 import React from 'react'
-import withContentValidation from '../../../hoc/withContentValidation'
+import withContentValidation, {
+  DropedProps
+} from '../../../hoc/withContentValidation'
+import { blockTypeClassname } from '../../../utils/getClassname'
 
-function TableOfContents() {
-  return <div>Table of contents</div>
+type tableItemProps ={slugifyFn: ((text: string) => string) | null, plainText: string}
+function TableItem ({ slugifyFn, plainText }: tableItemProps) {
+  if (!slugifyFn) return <React.Fragment>{plainText}</React.Fragment>
+
+  return (
+    <a href={`#${slugifyFn(plainText)}`}>
+      {plainText}
+    </a>
+  )
+}
+
+function TableOfContents({ className, index, slugifyFn }: DropedProps) {
+  if (!index) return null
+
+  return (
+    <ul className={className}>
+      {index.map(({ id, plainText, type }) => (
+        <li key={id} className={blockTypeClassname(type)}>
+          <TableItem slugifyFn={slugifyFn} plainText={plainText}/>
+        </li>
+      ))}
+    </ul>
+  )
 }
 
 export default withContentValidation(TableOfContents)

--- a/src/components/core/Render/index.tsx
+++ b/src/components/core/Render/index.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react'
 import { NotionBlock } from '../../../types/NotionBlock'
 import getBlocksToRender from '../../../utils/getBlocksToRender'
+import { indexGenerator } from '../../../utils/indexGenerator'
 
 interface Props {
   blocks: NotionBlock[]
@@ -23,6 +24,7 @@ function Render({
 
   const render = useMemo(() => {
     const renderBlocks = getBlocksToRender(blocks)
+    const index = indexGenerator(blocks)
 
     return renderBlocks.map((block) => {
       const Component = block.getComponent()
@@ -36,6 +38,7 @@ function Render({
           block={block}
           slugifyFn={slugifyFn}
           simpleTitles={simpleTitles}
+          index={index}
         />
           )
         : null

--- a/src/hoc/withContentValidation/constants.tsx
+++ b/src/hoc/withContentValidation/constants.tsx
@@ -33,6 +33,7 @@ export function getDefaultProps (props: WithContentValidationProps) {
     children: block.content?.text.map((text: Text, index: number) => (
       <RenderText key={index} {...text} />
     )),
-    language: block.content?.language
+    language: block.content?.language,
+    index: props.index
   }
 }

--- a/src/hoc/withContentValidation/index.tsx
+++ b/src/hoc/withContentValidation/index.tsx
@@ -1,10 +1,11 @@
 import React, { PropsWithChildren } from 'react'
 
-import { ParsedBlock } from '../../types/Block'
+import { ParsedBlock, SimpleBlock } from '../../types/Block'
 
 import EmptyBlock from '../../components/common/EmptyBlock'
 import { getDefaultProps, getMediaProps } from './constants'
 import { slugify } from '../../utils/slugify'
+import { blockTypeClassname } from '../../utils/getClassname'
 
 export interface WithContentValidationProps {
   classNames?: boolean
@@ -12,6 +13,7 @@ export interface WithContentValidationProps {
   block: ParsedBlock
   slugifyFn?: (text: string) => string
   simpleTitles?: boolean
+  index?: SimpleBlock[]
 }
 
 export type DropedProps = PropsWithChildren<{
@@ -29,6 +31,7 @@ export type DropedProps = PropsWithChildren<{
     extension?: string
     player?: string
   }
+  index?: SimpleBlock[]
 }>
 
 function withContentValidation(
@@ -41,12 +44,17 @@ function withContentValidation(
     simpleTitles,
     ...props
   }: WithContentValidationProps) => {
+    const hasContent = props.block.hasContent()
+    if (!hasContent && !emptyBlocks) {
+      return null
+    }
+
     let returnedProps: DropedProps = {
       checked: false,
       children: null,
       plainText: '',
       slugifyFn: simpleTitles ? null : (slugifyFn ?? slugify),
-      className: classNames ? `rnr-${props.block.notionType}` : undefined,
+      className: classNames ? blockTypeClassname(props.block.notionType) : undefined,
       config: {
         classNames: classNames,
         block: props.block,
@@ -58,15 +66,6 @@ function withContentValidation(
       returnedProps.media = getMediaProps(props)
     } else {
       returnedProps = { ...returnedProps, ...getDefaultProps(props) }
-    }
-
-    const hasContent =
-      returnedProps.plainText.trim() !== '' ||
-      returnedProps.config.block.items?.length ||
-      returnedProps.media
-
-    if (!hasContent && !emptyBlocks) {
-      return null
     }
 
     return hasContent ? <Component {...returnedProps} /> : <EmptyBlock />

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -17,3 +17,21 @@
   margin: var(--spacing) 0;
   padding-left: var(--children-spacing);
 }
+
+/* Table of contents */
+:global(.rnr-container) :global(.rnr-table_of_contents) {
+  list-style: none;
+  padding: 0;
+}
+
+:global(.rnr-container) :global(.rnr-table_of_contents) > li {
+  padding: 3px 0;
+}
+
+:global(.rnr-container) :global(.rnr-table_of_contents) > :global(.rnr-heading_2) {
+  margin-left: 30px;
+}
+
+:global(.rnr-container) :global(.rnr-table_of_contents) > :global(.rnr-heading_3) {
+  margin-left: 60px;
+}

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -45,3 +45,11 @@
   border: 1px solid var(--color-gray);
   padding: 5px;
 }
+
+:global(.rnr-container) :global(.has-column-header) tr:first-child > td {
+  background-color: var(--light-color);
+}
+
+:global(.rnr-container) :global(.has-row-header) tr > td:first-child {
+  background-color: var(--light-color);
+}

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -35,3 +35,13 @@
 :global(.rnr-container) :global(.rnr-table_of_contents) > :global(.rnr-heading_3) {
   margin-left: 60px;
 }
+
+/* Table */
+:global(.rnr-container) :global(.rnr-table) {
+  border-collapse: collapse;
+}
+
+:global(.rnr-container) :global(.rnr-table) td {
+  border: 1px solid var(--color-gray);
+  padding: 5px;
+}

--- a/src/types/Block.ts
+++ b/src/types/Block.ts
@@ -192,6 +192,10 @@ export class ParsedBlock {
     return this.getType() === 'CONTAINER'
   }
 
+  isTableOfContents() {
+    return this.notionType === blockEnum.TABLE_OF_CONTENTS
+  }
+
   equalsType(type: blockEnum) {
     return this.notionType === type
   }
@@ -201,4 +205,18 @@ export class ParsedBlock {
 
     this.items.push(new ParsedBlock(block, true))
   }
+
+  hasContent() {
+    return this.getPlainText().trim() !== '' ||
+    this.items?.length ||
+    this.isTableOfContents()
+  }
 }
+
+export type SimpleBlock = {
+  id: string;
+  type: blockEnum;
+  text: Text[] | undefined;
+  plainText: string;
+  subItems?: SimpleBlock[];
+};

--- a/src/types/Block.ts
+++ b/src/types/Block.ts
@@ -153,6 +153,8 @@ export class ParsedBlock {
       case blockEnum.PDF:
       case blockEnum.EMBED:
         return 'MEDIA'
+      case blockEnum.SYNCED_BLOCK:
+        return 'CONTAINER'
       default:
         return 'ELEMENT'
     }
@@ -180,6 +182,10 @@ export class ParsedBlock {
 
   isEmbed() {
     return this.getType() === 'MEDIA' && this.notionType === blockEnum.EMBED
+  }
+
+  isContainer() {
+    return this.getType() === 'CONTAINER'
   }
 
   equalsType(type: blockEnum) {

--- a/src/types/Block.ts
+++ b/src/types/Block.ts
@@ -13,6 +13,7 @@ import { NotionBlock } from './NotionBlock'
 import Text from './Text'
 import Divider from '../components/common/Divider'
 import Code from '../components/common/Code'
+import TableOfContents from '../components/common/TableOfContents'
 
 export class ParsedBlock {
   id: string
@@ -116,6 +117,9 @@ export class ParsedBlock {
       }
       case blockEnum.CODE: {
         return Code
+      }
+      case blockEnum.TABLE_OF_CONTENTS: {
+        return TableOfContents
       }
       default: {
         return null

--- a/src/types/Block.ts
+++ b/src/types/Block.ts
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 import DummyText from '../components/common/DummyText'
 import Embed from '../components/common/Embed/wrappedEmbed'
 import File from '../components/common/File'
@@ -14,6 +15,7 @@ import Text from './Text'
 import Divider from '../components/common/Divider'
 import Code from '../components/common/Code'
 import TableOfContents from '../components/common/TableOfContents'
+import Table from '../components/common/Table'
 
 export class ParsedBlock {
   id: string
@@ -34,8 +36,11 @@ export class ParsedBlock {
     icon?: {
       type: 'emoji'
       emoji: string
-    },
+    }
     language?: string
+    hasColumnHeader?: boolean
+    hasRowHeader?: boolean
+    cells?: (Text[])[]
   }
 
   constructor(initialValues: NotionBlock, isChild?: boolean) {
@@ -54,7 +59,20 @@ export class ParsedBlock {
       this.content = null
       this.items = [new ParsedBlock(initialValues, true)]
     } else {
-      const { text, checked, caption, type, external, file, url, icon, language } = content
+      const {
+        text,
+        checked,
+        caption,
+        type,
+        external,
+        file,
+        url,
+        icon,
+        language,
+        has_column_header,
+        has_row_header,
+        cells
+      } = content
 
       this.items =
         content.children?.map(
@@ -69,7 +87,10 @@ export class ParsedBlock {
         file,
         url,
         icon,
-        language
+        language,
+        hasColumnHeader: has_column_header,
+        hasRowHeader: has_row_header,
+        cells
       }
     }
   }
@@ -121,6 +142,9 @@ export class ParsedBlock {
       case blockEnum.TABLE_OF_CONTENTS: {
         return TableOfContents
       }
+      case blockEnum.TABLE: {
+        return Table
+      }
       default: {
         return null
       }
@@ -159,6 +183,9 @@ export class ParsedBlock {
         return 'MEDIA'
       case blockEnum.SYNCED_BLOCK:
         return 'CONTAINER'
+      case blockEnum.TABLE:
+      case blockEnum.TABLE_OF_CONTENTS:
+        return 'TABLE'
       default:
         return 'ELEMENT'
     }
@@ -192,8 +219,8 @@ export class ParsedBlock {
     return this.getType() === 'CONTAINER'
   }
 
-  isTableOfContents() {
-    return this.notionType === blockEnum.TABLE_OF_CONTENTS
+  isTable() {
+    return this.getType() === 'TABLE'
   }
 
   equalsType(type: blockEnum) {
@@ -207,16 +234,18 @@ export class ParsedBlock {
   }
 
   hasContent() {
-    return this.getPlainText().trim() !== '' ||
-    this.items?.length ||
-    this.isTableOfContents()
+    return (
+      this.getPlainText().trim() !== '' ||
+      this.items?.length ||
+      this.isTable()
+    )
   }
 }
 
 export type SimpleBlock = {
-  id: string;
-  type: blockEnum;
-  text: Text[] | undefined;
-  plainText: string;
-  subItems?: SimpleBlock[];
-};
+  id: string
+  type: blockEnum
+  text: Text[] | undefined
+  plainText: string
+  subItems?: SimpleBlock[]
+}

--- a/src/types/BlockTypes.ts
+++ b/src/types/BlockTypes.ts
@@ -19,6 +19,7 @@ export enum blockEnum {
   DIVIDER = 'divider',
   CODE = 'code',
   SYNCED_BLOCK = 'synced_block',
+  TABLE_OF_CONTENTS = 'table_of_contents',
 }
 
 export const UNSUPPORTED_TYPE = 'unsupported'

--- a/src/types/BlockTypes.ts
+++ b/src/types/BlockTypes.ts
@@ -17,7 +17,8 @@ export enum blockEnum {
   CALLOUT = 'callout',
   QUOTE = 'quote',
   DIVIDER = 'divider',
-  CODE = 'code'
+  CODE = 'code',
+  SYNCED_BLOCK = 'synced_block',
 }
 
 export const UNSUPPORTED_TYPE = 'unsupported'

--- a/src/types/BlockTypes.ts
+++ b/src/types/BlockTypes.ts
@@ -20,6 +20,8 @@ export enum blockEnum {
   CODE = 'code',
   SYNCED_BLOCK = 'synced_block',
   TABLE_OF_CONTENTS = 'table_of_contents',
+  TABLE = 'table',
+  TABLE_ROW = 'table_row',
 }
 
 export const UNSUPPORTED_TYPE = 'unsupported'

--- a/src/types/NotionBlock.ts
+++ b/src/types/NotionBlock.ts
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 import { blockEnum } from './BlockTypes'
 import Text from './Text'
 
@@ -17,11 +18,8 @@ interface Block {
   id: string
   type: blockEnum | string
   object: 'block' | 'database' | 'page' | string
-  // eslint-disable-next-line camelcase
   created_time: Date | string
-  // eslint-disable-next-line camelcase
   last_edited_time: Date | string
-  // eslint-disable-next-line camelcase
   has_children: boolean
   [blockEnum.HEADING1]?: BlockTypeContent
   [blockEnum.HEADING2]?: BlockTypeContent
@@ -31,6 +29,14 @@ interface Block {
   [blockEnum.ENUM_LIST]?: BlockTypeContent
   [blockEnum.CHECK_LIST]?: BlockTypeContent
   [blockEnum.TOGGLE_LIST]?: BlockTypeContent
+  [blockEnum.TABLE]?: BlockTypeContent & {
+    has_column_header: boolean
+    has_row_header: boolean
+    table_width: number
+  }
+  [blockEnum.TABLE_ROW]?: BlockTypeContent & {
+    cells: Text[];
+  }
 }
 
 export type NotionBlock = Block | Title

--- a/src/utils/getBlocksToRender.ts
+++ b/src/utils/getBlocksToRender.ts
@@ -28,7 +28,11 @@ export default function getBlocksToRender(blocks: NotionBlock[]): ParsedBlock[] 
     if (previousBlock && areRelated(previousBlock, block)) {
       previousBlock.addItem(cleanBlocks[i])
     } else {
-      returnBlocks.push(block)
+      if (block.isContainer() && block.items) {
+        returnBlocks.push(...block.items)
+      } else {
+        returnBlocks.push(block)
+      }
     }
   }
 

--- a/src/utils/getClassname.ts
+++ b/src/utils/getClassname.ts
@@ -1,3 +1,4 @@
+import { blockEnum } from '..'
 import Text from '../types/Text'
 
 const DEFAULT_COLOR = 'default'
@@ -11,4 +12,8 @@ export function getClassname(annotations: Text['annotations']) {
   ${annotations.underline ? 'rnr-underline' : ''}
   ${annotations.color !== DEFAULT_COLOR ? `rnr-${annotations.color}` : ''}
 `.trim()
+}
+
+export function blockTypeClassname(notionType: blockEnum) {
+  return `rnr-${notionType}`
 }

--- a/src/utils/indexGenerator.ts
+++ b/src/utils/indexGenerator.ts
@@ -1,7 +1,7 @@
-import { ParsedBlock } from '../types/Block'
+import { ParsedBlock, SimpleBlock } from '../types/Block'
 import { NotionBlock } from '../types/NotionBlock'
 
-export function indexGenerator(blocks: NotionBlock[]) {
+export function indexGenerator(blocks: NotionBlock[]): SimpleBlock[] {
   const parsedBlocks = blocks.map(block => new ParsedBlock(block))
 
   const titles = parsedBlocks.filter(block => block.isTitle())

--- a/src/utils/indexGenerator.ts
+++ b/src/utils/indexGenerator.ts
@@ -3,8 +3,15 @@ import { NotionBlock } from '../types/NotionBlock'
 
 export function indexGenerator(blocks: NotionBlock[]): SimpleBlock[] {
   const parsedBlocks = blocks.map(block => new ParsedBlock(block))
+  const titles = []
 
-  const titles = parsedBlocks.filter(block => block.isTitle())
+  for (let i = 0; i < parsedBlocks.length; i++) {
+    if (parsedBlocks[i].isTitle()) {
+      titles.push(parsedBlocks[i])
+    } else if (parsedBlocks[i].isContainer() && parsedBlocks[i].items) {
+      titles.push(...parsedBlocks[i].items!.filter(block => block.isTitle()))
+    }
+  }
 
   return titles.map((title) => ({
     id: title.id,


### PR DESCRIPTION
Add support to: 
 - Synced blocks
 - Tables
![image](https://user-images.githubusercontent.com/38046239/151610638-22ad1abc-2e16-4501-8fef-cf27ba02a398.png)
 - Table of contents
![image](https://user-images.githubusercontent.com/38046239/151610690-22119b22-5c1a-424f-b748-296647e0ff6f.png)

Issue: #108 

Candidate release date: 2022-01-31 🚀 