### PR TITLE
v3.8.3: Take text from rich_text instead of text

### DIFF
--- a/dev-example/package.json
+++ b/dev-example/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@9gustin/react-notion-render": "file:..",
-    "@notionhq/client": "^0.1.8",
+    "@notionhq/client": "^1.0.4",
     "next": "10.2.3",
     "react": "file:../node_modules/react",
     "react-dom": "file:../node_modules/react-dom"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@9gustin/react-notion-render",
-  "version": "3.8.2",
+  "version": "3.8.3-beta.0",
   "description": "A library to render notion content",
   "author": "9gustin",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^12.0.0",
-    "@testing-library/user-event": "^13.1.9",
+    "@testing-library/user-event": "^14.1.1",
     "@types/jest": "^27.0.1",
     "@types/node": "^17.0.7",
     "@types/react": "^17.0.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@9gustin/react-notion-render",
-  "version": "3.8.3-beta.0",
+  "version": "3.8.3",
   "description": "A library to render notion content",
   "author": "9gustin",
   "keywords": [

--- a/src/types/Block.ts
+++ b/src/types/Block.ts
@@ -60,7 +60,7 @@ export class ParsedBlock {
       this.items = [new ParsedBlock(initialValues, true)]
     } else {
       const {
-        text,
+        rich_text,
         checked,
         caption,
         type,
@@ -79,7 +79,7 @@ export class ParsedBlock {
           (child: NotionBlock) => new ParsedBlock(child, true)
         ) ?? null
       this.content = {
-        text: text ?? [],
+        text: rich_text ?? [],
         checked,
         caption,
         type,

--- a/src/types/Block.ts
+++ b/src/types/Block.ts
@@ -61,6 +61,7 @@ export class ParsedBlock {
     } else {
       const {
         rich_text,
+        text,
         checked,
         caption,
         type,
@@ -79,7 +80,7 @@ export class ParsedBlock {
           (child: NotionBlock) => new ParsedBlock(child, true)
         ) ?? null
       this.content = {
-        text: rich_text ?? [],
+        text: rich_text ?? text ?? [],
         checked,
         caption,
         type,


### PR DESCRIPTION
# v3.8.3: Take text from rich_text instead of text

Now the Notion API sends the text property inside of `rich_text` instead of `text`. Add support to this.

Solve issue #132 