### PR TITLE
feat: add prop for mapping page url to Render component

### DIFF
--- a/src/components/core/Render/index.tsx
+++ b/src/components/core/Render/index.tsx
@@ -11,6 +11,7 @@ interface Props {
   classNames?: boolean
   emptyBlocks?: boolean
   slugifyFn?: (text: string) => string
+  mapPageUrlFn?: (input: any) => string
   simpleTitles?: boolean
   blockComponentsMapper?: BlockComponentsMapperType
 }
@@ -21,6 +22,7 @@ function Render({
   emptyBlocks,
   useStyles,
   slugifyFn,
+  mapPageUrlFn,
   simpleTitles,
   blockComponentsMapper
 }: Props) {
@@ -41,6 +43,7 @@ function Render({
           emptyBlocks={emptyBlocks}
           block={block}
           slugifyFn={slugifyFn}
+          mapPageUrlFn={mapPageUrlFn}
           simpleTitles={simpleTitles}
           index={index}
           blockComponentsMapper={blockComponentsMapper}

--- a/src/components/core/Text/index.tsx
+++ b/src/components/core/Text/index.tsx
@@ -6,7 +6,8 @@ import { getClassname } from '../../../utils/getClassname'
 import Link from '../../common/Link'
 import withCustomComponent from '../../../hoc/withCustomComponent'
 
-export function Text({ text, annotations, type, href, plain_text }: IText) {
+export function Text(props: IText) {
+  const { text, annotations, type, href, plain_text, mapPageUrlFn } = props
   const className = getClassname(annotations)
 
   if (type === 'mention') {
@@ -35,7 +36,13 @@ export function Text({ text, annotations, type, href, plain_text }: IText) {
     element = <u className={className}>{text.content}</u>
   }
 
-  if (text.link) element = <Link url={text.link.url} className={className}>{element}</Link>
+  if (text.link) {
+    let { link: { url } } = text
+    if (url[0] === "/" && mapPageUrlFn) {
+      url = mapPageUrlFn(url.slice(1))
+    }
+    element = <Link url={url} className={className}>{element}</Link>
+  }
 
   return element
 }

--- a/src/hoc/withContentValidation/constants.tsx
+++ b/src/hoc/withContentValidation/constants.tsx
@@ -24,7 +24,7 @@ export function getMediaProps (props: WithContentValidationProps) {
 }
 
 export function getDefaultProps (props: WithContentValidationProps) {
-  const { block } = props
+  const { block, mapPageUrlFn } = props
   const plainText = block.getPlainText()
 
   return {
@@ -35,7 +35,7 @@ export function getDefaultProps (props: WithContentValidationProps) {
       if (block.supportCustomComponents() && !text.annotations.code) {
         TextComponent = WrappedText
       }
-      return <TextComponent key={index} {...text} />
+      return <TextComponent key={index} {...text} mapPageUrlFn={mapPageUrlFn} />
     }),
     language: block.content?.language,
     index: props.index,

--- a/src/hoc/withContentValidation/index.tsx
+++ b/src/hoc/withContentValidation/index.tsx
@@ -13,6 +13,7 @@ export interface WithContentValidationProps {
   emptyBlocks?: boolean
   block: ParsedBlock
   slugifyFn?: (text: string) => string
+  mapPageUrlFn?: (input: any) => string
   simpleTitles?: boolean
   index?: SimpleBlock[]
   blockComponentsMapper?: BlockComponentsMapperType

--- a/src/types/Text.ts
+++ b/src/types/Text.ts
@@ -21,4 +21,5 @@ export default interface Text {
   // eslint-disable-next-line camelcase
   plain_text: string
   href?: string
+  mapPageUrlFn?: (input: any) => string
 }


### PR DESCRIPTION
In notion, a n internal page is linked to by its id, for example `/1a2b3c4d`.

However, users of `react-notion-render` may use a different slug system to programmatically pages. The Notion page above may be available at `/another-notion-page`.

Without a remapping system, readers may click on `/1a2b3c4d` and will be led to a 404 page, while that page may indeed exist.

I've added an optional prop to `Render` component that allows users to specify how `react-notion-render` should rewrite an internal url. It is up to users to define how they would like to map an internal Notion page.

Example of how this `mapPageUrl` may be used:

Suppose the page for programmatically creating Notion page is at `pages/[pageId].js`.

The default component receives a prop named `blockChildren`, which is an array from [querying block children of a page](https://developers.notion.com/reference/get-block-children).

```
import { Render } from "@9gustin/react-notion-render"

export default function PageFromNotion({ blockChildren }) {
  const recordMap = {
    '3debf421b45d49458ae22833aef75047': 'internal-linking-with-gatsby-and-notion',
    'e224319d0c7440b7b0c2c89f54192eb4': 'rendering-code-block'
  }
  const mapPageUrl = (map) => (pageId = '') => {
    return map[pageId]
  }
    const siteMapPageUrl = React.useMemo(() => {
      return mapPageUrl(recordMap)
    }, [recordMap])
  return (
    <Render blocks={blockChildren} mapPageUrlFn={siteMapPageUrl} />
  )
}
```

Here, the `recordMap` is hard-coded, but it can be constructed from [querying a database](https://developers.notion.com/reference/post-database-query) and then map each page ID to its slug. Again, users are free to define this map.

What do you think?