### PR TITLE
Open internal pages link on the new tab

### DIFF
--- a/src/components/core/Text/index.tsx
+++ b/src/components/core/Text/index.tsx
@@ -11,8 +11,13 @@ export function Text(props: IText) {
   const className = getClassname(annotations)
 
   if (type === 'mention') {
+    const redirectProps = props.mention?.type === 'page'
+      ? {
+        target: '_blank', rel: 'noreferrer'
+      } : {}
+
     return (
-      <a className={`rnr-mention ${className}`} href={href}>
+      <a className={`rnr-mention ${className}`} href={href} {...redirectProps}>
         {plain_text}
       </a>
     )

--- a/src/types/Text.ts
+++ b/src/types/Text.ts
@@ -21,5 +21,8 @@ export default interface Text {
   // eslint-disable-next-line camelcase
   plain_text: string
   href?: string
+  mention?: {
+    type: string
+  }
   mapPageUrlFn?: (input: any) => string
 }


### PR DESCRIPTION
Link to the internal pages has a `mention` type in notion API:
```
{
            "type": "mention",
            "mention": {
                "type": "page",
                "page": {
                    "id": "2468a3-44a5-73dd-458c7-7863adc09"
                }
            },
            "plain_text": "link test",
            "href": "https://www.notion.so/2468a344a573dd458c77863adc09"
}
```

And there is no option to make it open on the new tab- this would be useful to have such behaviour by default, or on-demand.